### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
 feather/
+api-extractor.json
+tsconfig.json
+.svgrrc.js
+.gitmodules


### PR DESCRIPTION
Do not include development files within package.

Currently some of unneeded files are included within a package
https://unpkg.com/browse/react-native-feather@1.0.7/
